### PR TITLE
Allow SDK to use PTBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 # `ramm-sui-sdk`
 
+## Building the library
+
+`yarn`
+
+## Testing the library
+
+`yarn test`
+
+Note that tests require a `.env` file in the root of the repository with a Sui `PRIVATE_KEY` (testnet),
+with a sufficient `Coin<SUI>` balance for trades.
+
 # License
 
 This project is distributed under [AGPL-3.0-only](LICENSE).

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,16 +142,18 @@ export class RAMMSuiPool {
      * The returned transaction for the liquidity deposit can signed using a TS SDK keypair, and
      * then sent to the Sui network for execution.
      *
+     * @param txb The transaction block to which the liquidity deposit will be added.
      * @param param.assetIn The Sui Move type of the asset going into the pool.
-     * @param param.amountIn ID of the coin object with the amount to deposit into the pool.
+     * @param param.amountIn The coin object with the amount to deposit into the pool.
+     * It may come from the result of a previous transaction in the transaction block.
      * @returns The transaction block containing the liquidity deposit `moveCall`.
      */
-    liquidityDeposit(param: {
-        assetIn: string,
-        amountIn: string,
-    }): TransactionBlock {
-        const txb = new TransactionBlock();
-
+    liquidityDeposit(
+        txb: TransactionBlock,
+        param: {
+            assetIn: string,
+            amountIn: string,
+    }) {
         let assetAggregators = this.assetConfigs.map(
             (assetConfig) => {
                 let str = assetConfig.assetAggregator;
@@ -181,8 +183,6 @@ export class RAMMSuiPool {
                 param.assetIn,
             ].concat(otherAssetTypes),
         });
-
-        return txb
     }
 
     /**
@@ -191,16 +191,18 @@ export class RAMMSuiPool {
      * The returned transaction for the liquidity withdrawal can be signed using a TS SDK keypair,
      * and then sent to the Sui network for execution.
      *
+     * @param txb The transaction block to which the liquidity withdrawal will be added.
      * @param param.assetOut The Sui Move type of the asset being withdrawn from the pool.
-     * @param param.lpToken ID of the coin object with the LP tokens to redeem from the pool.
+     * @param param.lpToken The coin object with the LP tokens to redeem from the pool.
+     * It may be the result of a previous transaction in the transaction block.
      * @returns The transaction block containing the liquidity withdrawal `moveCall`.
      */
-    liquidityWithdrawal(param: {
-        assetOut: string,
-        lpToken: string,
-    }): TransactionBlock {
-        const txb = new TransactionBlock();
-
+    liquidityWithdrawal(
+        txb: TransactionBlock,
+        param: {
+            assetOut: string,
+            lpToken: string,
+    }) {
         const assetAggregators = this.assetConfigs.map(
             (assetConfig) => {
                 let str = assetConfig.assetAggregator;
@@ -224,8 +226,6 @@ export class RAMMSuiPool {
             ].concat(assetAggregators),
             typeArguments: assetTypes
         });
-
-        return txb
     }
 
     /**
@@ -235,7 +235,7 @@ export class RAMMSuiPool {
      * @param param.assetIn The Sui Move type of the asset going into the pool.
      * @param param.assetOut The Sui Move type of the asset coming out of the pool.
      * @param param.amountIn The coin object with the amount to deposit into the pool.
-     * It may the result of a previous transaction in the transaction block.
+     * It may come from the result of a previous transaction in the transaction block.
      * @param param.minAmountOut The minimum amount the trade is willing to receive in their
      * trade.
      * @returns The transaction block containing the "sell" trade's `moveCall`.

--- a/src/types.ts
+++ b/src/types.ts
@@ -231,9 +231,11 @@ export class RAMMSuiPool {
     /**
      * Create a PTB to perform a "sell" trade on a Sui RAMM pool.
      *
+     * @param txb The transaction block to which the trade will be added.
      * @param param.assetIn The Sui Move type of the asset going into the pool.
      * @param param.assetOut The Sui Move type of the asset coming out of the pool.
      * @param param.amountIn The coin object with the amount to deposit into the pool.
+     * It may the result of a previous transaction in the transaction block.
      * @param param.minAmountOut The minimum amount the trade is willing to receive in their
      * trade.
      * @returns The transaction block containing the "sell" trade's `moveCall`.
@@ -245,7 +247,7 @@ export class RAMMSuiPool {
             assetOut: string,
             amountIn: TransactionObjectInput,
             minAmountOut: number,
-    }): TransactionBlock {
+    }) {
         let assetAggregators = this.assetConfigs.map(
             (assetConfig) => {
                 let str = assetConfig.assetAggregator;
@@ -289,13 +291,12 @@ export class RAMMSuiPool {
                 param.assetOut,
             ].concat(otherAssetTypes),
         });
-
-        return txb
     }
 
     /**
      * Create a PTB to perform a "buy" trade on a Sui RAMM pool.
      *
+     * @param txb The transaction block to which the trade will be added.
      * @param param.assetIn The Sui Move type of the asset going into the pool.
      * @param param.assetOut The Sui Move type of the asset coming out of the pool.
      * @param param.amountOut The trader's exact desired amount of the outgoing asset.
@@ -304,14 +305,14 @@ export class RAMMSuiPool {
      * trade.
      * @returns The transaction block containing the "buy" trade's `moveCall`.
      */
-    tradeAmountOut(param: {
-        assetIn: string,
-        assetOut: string,
-        amountOut: number,
-        maxAmountIn: string,
-    }): TransactionBlock {
-        const txb = new TransactionBlock();
-
+    tradeAmountOut(
+        txb: TransactionBlock,
+        param: {
+            assetIn: string,
+            assetOut: string,
+            amountOut: number,
+            maxAmountIn: TransactionObjectInput,
+    }) {
         let assetAggregators = this.assetConfigs.map(
             (assetConfig) => {
                 let str = assetConfig.assetAggregator;
@@ -355,7 +356,5 @@ export class RAMMSuiPool {
                 param.assetOut,
             ].concat(otherAssetTypes),
         });
-
-        return txb
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { TransactionBlock, TransactionObjectArgument } from '@mysten/sui.js/transactions';
+import { Inputs, TransactionBlock, TransactionObjectArgument, TransactionObjectInput } from '@mysten/sui.js/transactions';
 import { SUI_CLOCK_OBJECT_ID } from '@mysten/sui.js/utils';
 
 export class AssetConfig {
@@ -233,19 +233,19 @@ export class RAMMSuiPool {
      *
      * @param param.assetIn The Sui Move type of the asset going into the pool.
      * @param param.assetOut The Sui Move type of the asset coming out of the pool.
-     * @param param.amountIn ID of the coin object with the amount to deposit into the pool.
+     * @param param.amountIn The coin object with the amount to deposit into the pool.
      * @param param.minAmountOut The minimum amount the trade is willing to receive in their
      * trade.
      * @returns The transaction block containing the "sell" trade's `moveCall`.
      */
-    tradeAmountIn(param: {
-        assetIn: string,
-        assetOut: string,
-        amountIn: string,
-        minAmountOut: number,
+    tradeAmountIn(
+        txb: TransactionBlock,
+        param: {
+            assetIn: string,
+            assetOut: string,
+            amountIn: TransactionObjectInput,
+            minAmountOut: number,
     }): TransactionBlock {
-        const txb = new TransactionBlock();
-
         let assetAggregators = this.assetConfigs.map(
             (assetConfig) => {
                 let str = assetConfig.assetAggregator;

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,7 +152,7 @@ export class RAMMSuiPool {
         txb: TransactionBlock,
         param: {
             assetIn: string,
-            amountIn: string,
+            amountIn: TransactionObjectInput,
     }) {
         let assetAggregators = this.assetConfigs.map(
             (assetConfig) => {
@@ -201,7 +201,7 @@ export class RAMMSuiPool {
         txb: TransactionBlock,
         param: {
             assetOut: string,
-            lpToken: string,
+            lpToken: TransactionObjectInput,
     }) {
         const assetAggregators = this.assetConfigs.map(
             (assetConfig) => {

--- a/tests/liquidityDeposit.test.ts
+++ b/tests/liquidityDeposit.test.ts
@@ -56,38 +56,20 @@ describe('Liquidity deposit', () => {
 
         // BTC has 8 decimal places, so this is 0.01 BTC.
         let btcAmount: number = 1_000_000;
-        txb.moveCall({
-            target: `${rammMiscFaucet.packageId}::${rammMiscFaucet.faucetModule}::mint_test_coins`,
+        let coin = txb.moveCall({
+            target: `${rammMiscFaucet.packageId}::${rammMiscFaucet.faucetModule}::mint_test_coins_ptb`,
             arguments: [txb.object(rammMiscFaucet.faucetAddress), txb.pure(btcAmount)],
             typeArguments: [btcType]
         });
 
-        await suiClient.signAndExecuteTransactionBlock({ signer: testKeypair, transactionBlock: txb });
-
-        // Wait for the network to register the test token request.
-        await sleep(600);
-
-        /**
-         * Perform the liquidity deposit using the SDK
-         */
-
-        let paginatedCoins = await suiClient.getCoins({
-            owner: testKeypair.toSuiAddress(),
-            coinType: btcType,
-        });
-        //console.log(paginatedCoins);
-
-        // Choose any of the test BTC coins the wallet may already have.
-        let btcId = paginatedCoins.data[0].coinObjectId;
-
-        let liqDepTxb = ramm.liquidityDeposit({
-            assetIn: btcType,
-            amountIn: btcId
-        });
+        ramm.liquidityDeposit(
+            txb,
+            { assetIn: btcType, amountIn: coin }
+        );
 
         let resp = await suiClient.signAndExecuteTransactionBlock({
             signer: testKeypair,
-            transactionBlock: liqDepTxb,
+            transactionBlock: txb,
             options: {
                 // required, so that we can scrutinize the response's events for a trade
                 showEvents: true
@@ -104,5 +86,5 @@ describe('Liquidity deposit', () => {
         expect(Number(liqDepEventJSON.amount_in)).toBeLessThanOrEqual(btcAmount);
         expect(Number(liqDepEventJSON.lpt)).toBeGreaterThan(0);
         expect(Number(liqDepEventJSON.lpt)).toBeLessThan(btcAmount);
-    }, /** timeout for the test, in ms */ 10_000);
+    }, /** timeout for the test, in ms */ 5_000);
 });

--- a/tests/liquidityDeposit.test.ts
+++ b/tests/liquidityDeposit.test.ts
@@ -51,12 +51,12 @@ describe('Liquidity deposit', () => {
          * Mint test coins from the `ramm-misc` package's `test_coin_faucet` module.
         */
 
-        let txb = new TransactionBlock();
-        let btcType: string = `${rammMiscFaucet.packageId}::${rammMiscFaucet.testCoinsModule}::BTC`;
+        const txb = new TransactionBlock();
+        const btcType: string = `${rammMiscFaucet.packageId}::${rammMiscFaucet.testCoinsModule}::BTC`;
 
         // BTC has 8 decimal places, so this is 0.01 BTC.
         let btcAmount: number = 1_000_000;
-        let coin = txb.moveCall({
+        const coin = txb.moveCall({
             target: `${rammMiscFaucet.packageId}::${rammMiscFaucet.faucetModule}::mint_test_coins_ptb`,
             arguments: [txb.object(rammMiscFaucet.faucetAddress), txb.pure(btcAmount)],
             typeArguments: [btcType]

--- a/tests/liquidityWithdrawal.test.ts
+++ b/tests/liquidityWithdrawal.test.ts
@@ -7,8 +7,9 @@ import {
 } from "./utils";
 
 import { getFullnodeUrl, SuiClient, SuiEvent } from '@mysten/sui.js/client';
+import { OwnedObjectRef } from "@mysten/sui.js/dist/cjs/types/objects";
 import { getFaucetHost, requestSuiFromFaucetV1 } from '@mysten/sui.js/faucet';
-import { TransactionBlock } from '@mysten/sui.js/transactions';
+import { Inputs, TransactionBlock } from '@mysten/sui.js/transactions';
 
 import { assert, describe, expect, test } from 'vitest';
 
@@ -51,46 +52,31 @@ describe('Liquidity withdrawal', () => {
          * Mint test coins from the `ramm-misc` package's `test_coin_faucet` module.
         */
 
-        const txb = new TransactionBlock();
+        let txb = new TransactionBlock();
         const btcType: string = `${rammMiscFaucet.packageId}::${rammMiscFaucet.testCoinsModule}::BTC`;
 
         // BTC has 8 decimal places, so this is 0.01 BTC.
         const btcAmount: number = 1_000_000;
-        txb.moveCall({
-            target: `${rammMiscFaucet.packageId}::${rammMiscFaucet.faucetModule}::mint_test_coins`,
+        let coin = txb.moveCall({
+            target: `${rammMiscFaucet.packageId}::${rammMiscFaucet.faucetModule}::mint_test_coins_ptb`,
             arguments: [txb.object(rammMiscFaucet.faucetAddress), txb.pure(btcAmount)],
             typeArguments: [btcType]
         });
 
-        await suiClient.signAndExecuteTransactionBlock({ signer: testKeypair, transactionBlock: txb });
-
-        // Wait for the network to register the test token request.
-        await sleep(600);
-
-        /**
-         * Perform the liquidity deposit using the SDK
-         */
-
-        const paginatedCoins = await suiClient.getCoins({
-            owner: testKeypair.toSuiAddress(),
-            coinType: btcType,
-        });
-        //console.log(paginatedCoins);
-
-        // Choose any of the test BTC coins the wallet may already have.
-        const btcId = paginatedCoins.data[0].coinObjectId;
-
-        const liqDepTxb = ramm.liquidityDeposit({
-            assetIn: btcType,
-            amountIn: btcId
-        });
+        ramm.liquidityDeposit(
+            txb,
+            { assetIn: btcType, amountIn: coin }
+        );
 
         let resp = await suiClient.signAndExecuteTransactionBlock({
             signer: testKeypair,
-            transactionBlock: liqDepTxb,
+            transactionBlock: txb,
             options: {
                 // required, so that we can scrutinize the response's events for a liq. dep.
-                showEvents: true
+                showEvents: true,
+                // required, so the object ID of the LP tokens can be fetched without
+                // having to perform another RPC call.
+                showEffects: true
             }
         });
 
@@ -98,21 +84,23 @@ describe('Liquidity withdrawal', () => {
          * Perform the liquidity withdrawal using the SDK
          */
 
-        const paginatedLPTokens = await suiClient.getCoins({
-            owner: testKeypair.toSuiAddress(),
-            coinType: `${ramm.packageId}::${ramm.moduleName}::LP<${btcType}>`,
+        let lpBtcObj: OwnedObjectRef = resp.effects!.created![0];
+        let lpBtc = Inputs.ObjectRef({
+            digest: lpBtcObj.reference.digest,
+            objectId: lpBtcObj.reference.objectId,
+            version: lpBtcObj.reference.version
         });
-        // Choose any of the LP<BTC> the wallet may already have.
-        const lpBtcId = paginatedLPTokens.data[0].coinObjectId;
 
-        const liqWithTxb = ramm.liquidityWithdrawal({
-            assetOut: btcType,
-            lpToken: lpBtcId
-        });
+        txb = new TransactionBlock();
+
+        ramm.liquidityWithdrawal(
+            txb,
+            { assetOut: btcType,  lpToken: lpBtc }
+        );
 
         resp = await suiClient.signAndExecuteTransactionBlock({
             signer: testKeypair,
-            transactionBlock: liqWithTxb,
+            transactionBlock: txb,
             options: {
                 // required, so that we can scrutinize the response's events for a liq. wthdrwl.
                 showEvents: true
@@ -144,5 +132,5 @@ describe('Liquidity withdrawal', () => {
                 }
             }
         })
-    }, /** timeout for the test, in ms */ 15_000);
+    }, /** timeout for the test, in ms */ 10_000);
 });

--- a/tests/liquidityWithdrawal.test.ts
+++ b/tests/liquidityWithdrawal.test.ts
@@ -57,7 +57,7 @@ describe('Liquidity withdrawal', () => {
 
         // BTC has 8 decimal places, so this is 0.01 BTC.
         const btcAmount: number = 1_000_000;
-        let coin = txb.moveCall({
+        const coin = txb.moveCall({
             target: `${rammMiscFaucet.packageId}::${rammMiscFaucet.faucetModule}::mint_test_coins_ptb`,
             arguments: [txb.object(rammMiscFaucet.faucetAddress), txb.pure(btcAmount)],
             typeArguments: [btcType]
@@ -72,8 +72,6 @@ describe('Liquidity withdrawal', () => {
             signer: testKeypair,
             transactionBlock: txb,
             options: {
-                // required, so that we can scrutinize the response's events for a liq. dep.
-                showEvents: true,
                 // required, so the object ID of the LP tokens can be fetched without
                 // having to perform another RPC call.
                 showEffects: true
@@ -84,8 +82,8 @@ describe('Liquidity withdrawal', () => {
          * Perform the liquidity withdrawal using the SDK
          */
 
-        let lpBtcObj: OwnedObjectRef = resp.effects!.created![0];
-        let lpBtc = Inputs.ObjectRef({
+        const lpBtcObj: OwnedObjectRef = resp.effects!.created![0];
+        const lpBtc = Inputs.ObjectRef({
             digest: lpBtcObj.reference.digest,
             objectId: lpBtcObj.reference.objectId,
             version: lpBtcObj.reference.version

--- a/tests/tradeAmountIn.test.ts
+++ b/tests/tradeAmountIn.test.ts
@@ -1,17 +1,13 @@
 import { suiConfigs } from "../src/constants";
 import { RAMMSuiPool } from "../src/types";
 import {
-    LiquidityWithdrawalEvent, RAMMMiscFaucet,
     TESTNET,
     TradeEvent,
     rammMiscFaucet, sleep, testKeypair
 } from "./utils";
 
 import { getFullnodeUrl, SuiClient, SuiEvent, SuiObjectChange } from '@mysten/sui.js/client';
-import { ObjectCallArg } from "@mysten/sui.js/dist/cjs/builder";
-import { OwnedObjectRef } from "@mysten/sui.js/dist/cjs/types/objects";
-import { getFaucetHost, requestSuiFromFaucetV1 } from '@mysten/sui.js/faucet';
-import { Inputs, TransactionBlock } from '@mysten/sui.js/transactions';
+import { TransactionBlock } from '@mysten/sui.js/transactions';
 
 import { assert, describe, expect, test } from 'vitest';
 
@@ -73,52 +69,11 @@ describe('Trade amount into RAMM', () => {
         let resp = await suiClient.signAndExecuteTransactionBlock({
             signer: testKeypair,
             transactionBlock: adaDotTxb,
-            options: {
-                // required, so the object ID of the LP tokens can be fetched without
-                // having to perform another RPC call.
-                showObjectChanges: true
-            }
         });
-
-        /*
-        Disambiguate between the two received LP tokens.
-        */
-
-        const [lpOne, lpTwo]: SuiObjectChange[] = resp.objectChanges!.filter((oc) => oc.type === 'created');
-        // we know that in this test, the only two "created" objects in the tx's changed objects
-        // will be the LP tokens; as such, both can be safely cast to the appropriate variant
-        // of `SuiObjectChange`.
-        const lpOneObj: ObjectCallArg = Inputs.ObjectRef({
-            // @ts-ignore
-            digest: lpOne.digest, 
-            // @ts-ignore
-            objectId: lpOne.objectId,
-            version: lpOne.version
-        });
-        const lpTwoObj: ObjectCallArg = Inputs.ObjectRef({
-            // @ts-ignore
-            digest: lpTwo.digest,
-            // @ts-ignore
-            objectId: lpTwo.objectId,
-            version: lpTwo.version
-        });
-
-        let adaLp: ObjectCallArg;
-        let dotLp: ObjectCallArg;
-        // @ts-ignore
-        if (lpOne.objectType === `0x2::coin::Coin<${ramm.packageId}::${ramm.moduleName}::LP<${adaType}>>`) {
-            adaLp = lpOneObj;
-            dotLp = lpTwoObj;
-        } else {
-            adaLp = lpTwoObj;
-            dotLp = lpOneObj;
-        }
 
         /*
         Onto the trade - perform the DOT "sell" trade using the SDK
         */
-
-        console.log('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
 
         const txb = new TransactionBlock();
 

--- a/tests/tradeAmountIn.test.ts
+++ b/tests/tradeAmountIn.test.ts
@@ -7,9 +7,10 @@ import {
     rammMiscFaucet, sleep, testKeypair
 } from "./utils";
 
-import { getFullnodeUrl, SuiClient, SuiEvent } from '@mysten/sui.js/client';
+import { getFullnodeUrl, SuiClient, SuiEvent, SuiObjectChange } from '@mysten/sui.js/client';
+import { OwnedObjectRef } from "@mysten/sui.js/dist/cjs/types/objects";
 import { getFaucetHost, requestSuiFromFaucetV1 } from '@mysten/sui.js/faucet';
-import { TransactionBlock } from '@mysten/sui.js/transactions';
+import { Inputs, TransactionBlock } from '@mysten/sui.js/transactions';
 
 import { assert, describe, expect, test } from 'vitest';
 
@@ -36,20 +37,9 @@ describe('Trade amount into RAMM', () => {
 
         console.log('Running test fror: ' + ramm.name);
 
-        /**
-         * Request SUI from the testnet's faucet.
-        */
-
-        await requestSuiFromFaucetV1({
-            host: getFaucetHost(TESTNET),
-            recipient: testKeypair.toSuiAddress(),
-        });
-
-        // Wait for the network to register the SUI faucet transaction.
-        await sleep(600);
-
-        /**
-         * Mint test coins from the `ramm-misc` package's `test_coin_faucet` module.
+        /*
+        Mint test coins from the `ramm-misc` package's `test_coin_faucet` module.
+        Then, perform liquidity deposits using the SDK.
         */
 
         const adaDotTxb = new TransactionBlock();
@@ -58,106 +48,93 @@ describe('Trade amount into RAMM', () => {
 
         // ADA has 8 decimal places, so this is 200 ADA.
         const adaLiqAmount: number = 20_000_000_000;
-        // This is 10 DOT
-        const dotLiqAmount: number = 1_000_000_000;
-        adaDotTxb.moveCall({
-            target: `${rammMiscFaucet.packageId}::${rammMiscFaucet.faucetModule}::mint_test_coins`,
+        const adaCoin = adaDotTxb.moveCall({
+            target: `${rammMiscFaucet.packageId}::${rammMiscFaucet.faucetModule}::mint_test_coins_ptb`,
             arguments: [adaDotTxb.object(rammMiscFaucet.faucetAddress), adaDotTxb.pure(adaLiqAmount)],
             typeArguments: [adaType]
         });
-        adaDotTxb.moveCall({
-            target: `${rammMiscFaucet.packageId}::${rammMiscFaucet.faucetModule}::mint_test_coins`,
+        // This is 10 DOT
+        const dotLiqAmount: number = 1_000_000_000;
+        const dotCoin = adaDotTxb.moveCall({
+            target: `${rammMiscFaucet.packageId}::${rammMiscFaucet.faucetModule}::mint_test_coins_ptb`,
             arguments: [adaDotTxb.object(rammMiscFaucet.faucetAddress), adaDotTxb.pure(dotLiqAmount)],
             typeArguments: [dotType]
         });
-        // This is 1 DOT, to be used for the trade.
-        const dotAmount: number = 100_000_000;
-        adaDotTxb.moveCall({
-            target: `${rammMiscFaucet.packageId}::${rammMiscFaucet.faucetModule}::mint_test_coins`,
-            arguments: [adaDotTxb.object(rammMiscFaucet.faucetAddress), adaDotTxb.pure(dotAmount)],
-            typeArguments: [dotType]
-        });
-
-        await suiClient.signAndExecuteTransactionBlock({ signer: testKeypair, transactionBlock: adaDotTxb });
-
-        // Wait for the network to register the test token request.
-        await sleep(600);
-
-        /**
-         * Perform liquidity deposits using the SDK
-         */
-
-        const paginatedAdaCoins = await suiClient.getCoins({
-            owner: testKeypair.toSuiAddress(),
-            coinType: adaType,
-        });
-
-        // Get the requested ADA coins' ID.
-        const adaId = paginatedAdaCoins.data[0].coinObjectId;
-
-        const paginatedDotCoins = await suiClient.getCoins({
-            owner: testKeypair.toSuiAddress(),
-            coinType: dotType,
-        });
-
-        // Get the requested DOT coins' ID.
-
-        let dotLiqId: string;
-        let dotId: string;
-
-        // Two DOT coins were requested:
-        // 1. a larger one, to be used for the liquidity deposit
-        // 2. a smaller one, to be used for the trade
-        if (BigInt(paginatedDotCoins.data[0].balance) > BigInt(paginatedDotCoins.data[1].balance)) {
-            [dotLiqId, dotId] = [paginatedDotCoins.data[0].coinObjectId, paginatedDotCoins.data[1].coinObjectId]
-        } else {
-            [dotLiqId, dotId] = [paginatedDotCoins.data[1].coinObjectId, paginatedDotCoins.data[0].coinObjectId]
-        }
-
-        // Deposit ADA and DOT liquidity, required for the test
-
-        const adaLiqDepTxb = ramm.liquidityDeposit({
-            assetIn: adaType,
-            amountIn: adaId
-        });
-
+        ramm.liquidityDeposit(
+            adaDotTxb,
+            { assetIn: adaType, amountIn: adaCoin }
+        );
+        ramm.liquidityDeposit(
+            adaDotTxb,
+            { assetIn: dotType, amountIn: dotCoin }
+        );
+    
         let resp = await suiClient.signAndExecuteTransactionBlock({
             signer: testKeypair,
-            transactionBlock: adaLiqDepTxb,
+            transactionBlock: adaDotTxb,
             options: {
-                // required, so that we can scrutinize the response's events for a liq. dep.
-                showEvents: true
+                // required, so the object ID of the LP tokens can be fetched without
+                // having to perform another RPC call.
+                showObjectChanges: true
             }
         });
 
-        const dotLiqDepTxb = ramm.liquidityDeposit({
-            assetIn: dotType,
-            amountIn: dotLiqId
+        /*
+        Disambiguate between the two received LP tokens.
+        */
+
+        const [lpOne, lpTwo]: SuiObjectChange[] = resp.objectChanges!.filter((oc) => oc.type === 'created');
+        const lpOneObj = Inputs.ObjectRef({
+            digest: lpOne.digest,
+            objectId: lpOne.objectId,
+            version: lpOne.version
         });
+        const lpTwoObj = Inputs.ObjectRef({
+            digest: lpTwo.digest,
+            objectId: lpTwo.objectId,
+            version: lpTwo.version
+        });
+
+        let adaLp: OwnedObjectRef;
+        let dotLp: OwnedObjectRef;
+        if (lpOne.objectType === `0x2::coin::Coin<${ramm.packageId}::${ramm.moduleName}::LP<${adaType}>>`) {
+            adaLp = lpOneObj;
+            dotLp = lpTwoObj;
+        } else {
+            adaLp = lpTwoObj;
+            dotLp = lpOneObj;
+        }
+
+        /*
+        Onto the trade - perform the DOT "sell" trade using the SDK
+        */
+
+        console.log('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
+
+        const txb = new TransactionBlock();
+
+        // This is 1 DOT, to be used for the trade.
+        const dotAmount: number = 100_000_000;
+        const coin = txb.moveCall({
+            target: `${rammMiscFaucet.packageId}::${rammMiscFaucet.faucetModule}::mint_test_coins_ptb`,
+            arguments: [txb.object(rammMiscFaucet.faucetAddress), txb.pure(dotAmount)],
+            typeArguments: [dotType]
+        });
+
+        ramm.tradeAmountIn(
+            txb,
+            {
+                assetIn: dotType,
+                assetOut: adaType,
+                amountIn: coin,
+                // we'd like at least 5 ADA for the 1 DOT
+                minAmountOut: 50_000_000,
+            }
+        );
 
         resp = await suiClient.signAndExecuteTransactionBlock({
             signer: testKeypair,
-            transactionBlock: dotLiqDepTxb,
-        });
-
-        // Wait for the network to register the liquidity deposits.
-        await sleep(600);
-
-        /**
-         * Perform the DOT "sell" trade using the SDK
-         */
-
-        const tradeInTxb = ramm.tradeAmountIn({
-            assetIn: dotType,
-            assetOut: adaType,
-            amountIn: dotId,
-            // we'd like at least 5 ADA for the 1 DOT
-            minAmountOut: 50_000_000,
-        });
-
-        resp = await suiClient.signAndExecuteTransactionBlock({
-            signer: testKeypair,
-            transactionBlock: tradeInTxb,
+            transactionBlock: txb,
             options: {
                 // required, so that we can scrutinize the response's events for a trade
                 showEvents: true
@@ -176,5 +153,5 @@ describe('Trade amount into RAMM', () => {
         expect(Number(tradeInEventJSON.protocol_fee)).toBeGreaterThan(0);
         expect(tradeInEventJSON.execute_trade).toBe(true);
 
-    }, /** timeout for the test, in ms */ 27_500);
+    }, /** timeout for the test, in ms */ 10_000);
 });

--- a/tests/tradeAmountIn.test.ts
+++ b/tests/tradeAmountIn.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./utils";
 
 import { getFullnodeUrl, SuiClient, SuiEvent, SuiObjectChange } from '@mysten/sui.js/client';
+import { ObjectCallArg } from "@mysten/sui.js/dist/cjs/builder";
 import { OwnedObjectRef } from "@mysten/sui.js/dist/cjs/types/objects";
 import { getFaucetHost, requestSuiFromFaucetV1 } from '@mysten/sui.js/faucet';
 import { Inputs, TransactionBlock } from '@mysten/sui.js/transactions';
@@ -84,19 +85,27 @@ describe('Trade amount into RAMM', () => {
         */
 
         const [lpOne, lpTwo]: SuiObjectChange[] = resp.objectChanges!.filter((oc) => oc.type === 'created');
-        const lpOneObj = Inputs.ObjectRef({
-            digest: lpOne.digest,
+        // we know that in this test, the only two "created" objects in the tx's changed objects
+        // will be the LP tokens; as such, both can be safely cast to the appropriate variant
+        // of `SuiObjectChange`.
+        const lpOneObj: ObjectCallArg = Inputs.ObjectRef({
+            // @ts-ignore
+            digest: lpOne.digest, 
+            // @ts-ignore
             objectId: lpOne.objectId,
             version: lpOne.version
         });
-        const lpTwoObj = Inputs.ObjectRef({
+        const lpTwoObj: ObjectCallArg = Inputs.ObjectRef({
+            // @ts-ignore
             digest: lpTwo.digest,
+            // @ts-ignore
             objectId: lpTwo.objectId,
             version: lpTwo.version
         });
 
-        let adaLp: OwnedObjectRef;
-        let dotLp: OwnedObjectRef;
+        let adaLp: ObjectCallArg;
+        let dotLp: ObjectCallArg;
+        // @ts-ignore
         if (lpOne.objectType === `0x2::coin::Coin<${ramm.packageId}::${ramm.moduleName}::LP<${adaType}>>`) {
             adaLp = lpOneObj;
             dotLp = lpTwoObj;

--- a/tests/tradeAmountOut.test.ts
+++ b/tests/tradeAmountOut.test.ts
@@ -6,10 +6,9 @@ import {
     rammMiscFaucet, sleep, testKeypair
 } from "./utils";
 
-import { getFullnodeUrl, SuiClient, SuiEvent, SuiObjectChange } from '@mysten/sui.js/client';
-import { ObjectCallArg } from "@mysten/sui.js/dist/cjs/builder";
+import { getFullnodeUrl, SuiClient, SuiEvent } from '@mysten/sui.js/client';
 import { getFaucetHost, requestSuiFromFaucetV1 } from '@mysten/sui.js/faucet';
-import { Inputs, TransactionBlock } from '@mysten/sui.js/transactions';
+import { TransactionBlock } from '@mysten/sui.js/transactions';
 
 import { assert, describe, expect, test } from 'vitest';
 
@@ -85,47 +84,7 @@ describe('Trade amount out of RAMM', () => {
         let resp = await suiClient.signAndExecuteTransactionBlock({
             signer: testKeypair,
             transactionBlock: btcEthTxb,
-            options: {
-                // required, so the object ID of the LP tokens can be fetched without
-                // having to perform another RPC call.
-                showObjectChanges: true
-            }
         });
-
-                /*
-        Disambiguate between the two received LP tokens.
-        */
-
-        const [lpOne, lpTwo]: SuiObjectChange[] = resp.objectChanges!.filter((oc) => oc.type === 'created');
-        // we know that in this test, the only two "created" objects in the tx's changed objects
-        // will be the LP tokens; as such, both can be safely cast to the appropriate variant
-        // of `SuiObjectChange`.
-        const lpOneObj: ObjectCallArg = Inputs.ObjectRef({
-            // @ts-ignore
-            digest: lpOne.digest, 
-            // @ts-ignore
-            objectId: lpOne.objectId,
-            version: lpOne.version
-        });
-        const lpTwoObj: ObjectCallArg = Inputs.ObjectRef({
-            // @ts-ignore
-            digest: lpTwo.digest,
-            // @ts-ignore
-            objectId: lpTwo.objectId,
-            version: lpTwo.version
-        });
-
-        let btcLp: ObjectCallArg;
-        let ethLp: ObjectCallArg;
-        // @ts-ignore
-        if (lpOne.objectType === `0x2::coin::Coin<${ramm.packageId}::${ramm.moduleName}::LP<${btcType}>>`) {
-            btcLp = lpOneObj;
-            ethLp = lpTwoObj;
-        } else {
-            btcLp = lpTwoObj;
-            ethLp = lpOneObj;
-        }
-
 
         /**
          * Perform the ETH "buy" trade using the SDK

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     poolOptions: {
       threads: {
-        // Threads related options here
+        // Tests cannot be run in parallel to avoid locking objects
         singleThread: true
       }
     }


### PR DESCRIPTION
Reworking the SDK from #1 to allow the use of RAMM operations in PTBs, where possible.
This will ease integration with the RAMM UI.

Closes #2 .