### PR TITLE
Rename `.envrc` vars in `.yarnrc.yml`

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,6 +4,6 @@ npmScopes:
   ramm:
     npmAlwaysAuth: true
     npmPublishRegistry: "https://gitlab.com/api/v4/projects/54281288/packages/npm/"
-    npmAuthToken: "${GITLAB_AUTH_TOKEN}"
+    npmAuthToken: "${RAMM_SUI_SDK_GITLAB_AUTH_TOKEN}"
 
 yarnPath: .yarn/releases/yarn-4.0.2.cjs


### PR DESCRIPTION
In order to accommodate integrating both `ramm-sdk` (Aldrin Labs' private GitLab library) and this `ramm-sui-sdk` (public library, with artifacts published to a private GL registry) into `ramm-ui` (private GL library) as dependencies, `yarn` needs to be given an `npmAuthToken`.

This tiny PR changes the name of the environment variable from which the GL authentication is loaded, connecting it to this project.

As such, the workflow for a developer working on all three packages should be to have an `.envrc` file in the parent directory of `ramm-sdk/ramm-sui-sdk/ramm-ui` with appropriately named variables, each exporting an access token for each of the libraries, with each token having the appropriate permissions e.g. `ramm-ui` isn't published, so it doesn't need write access to GL's private package registry.